### PR TITLE
Add support for environment variables in yaml config

### DIFF
--- a/sql-migrate/config.go
+++ b/sql-migrate/config.go
@@ -45,6 +45,7 @@ func ReadConfig() (map[string]*Environment, error) {
 		return nil, err
 	}
 
+	file = []byte(os.ExpandEnv(string(file)))
 	config := make(map[string]*Environment)
 	err = yaml.Unmarshal(file, config)
 	if err != nil {

--- a/sql-migrate/config_test.go
+++ b/sql-migrate/config_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestReadConfig_YAMLEnvVars(t *testing.T) {
+	configTemplate := `
+dynamic:
+    dialect: ${DIALECT}
+    datasource: ${DATASOURCE}
+    schema: ${SCHEMA}
+    table: ${TABLE}
+    dir: ${DIR}`
+
+	ConfigFile := testTempFile(t)
+	if err := ioutil.WriteFile(tf, []byte(configTemplate), 600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Setenv("DIALECT", "postgres"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Setenv("DATASOURCE", "postgres://user:password@localhost:5432/db?sslmode=disable"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Setenv("SCHEMA", "myschema"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Setenv("TABLE", "migrations"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Setenv("DIR", "migrations/sql"); err != nil {
+		t.Fatal(err)
+	}
+
+	env, err := ReadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]*Environment{
+		"dynamic": &Environment{
+			Dialect:    "postgres",
+			DataSource: "postgres://user:password@localhost:5432/db?sslmode=disable",
+			TableName:  "migrations",
+			Dir:        "migrations/sql",
+			SchemaName: "myschema",
+		},
+	}
+
+	if !reflect.DeepEqual(env, expected) {
+		t.Logf("Failed reading config.")
+		t.Logf("Got:  %s", env)
+		t.Errorf("Want: %s", expected)
+	}
+}
+
+func testTempFile(t *testing.T) string {
+	tf, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tf.Close()
+
+	return tf.Name()
+}


### PR DESCRIPTION
This PR adds support for YAML environment variables in the sql-migrate config.

https://www.elastic.co/guide/en/beats/winlogbeat/current/using-environ-vars.html

This addresses issue #5, which was closed, because of the false assumption, that this behavior is already supported. Thus I guess this is an easy fix, which could make its way to the upstream. Passing in configurations via flags could be additionally done in our fork in a follow-up PR.