### PR TITLE
Store migrations down in db

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -125,7 +125,6 @@ func (m Migration) VersionInt() int64 {
 
 type PlannedMigration struct {
 	*Migration
-
 	DisableTransaction bool
 	Queries            []string
 }
@@ -137,8 +136,9 @@ func (b byId) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 func (b byId) Less(i, j int) bool { return b[i].Less(b[j]) }
 
 type MigrationRecord struct {
-	Id        string    `db:"id"`
-	AppliedAt time.Time `db:"applied_at"`
+	Id            string    `db:"id"`
+	AppliedAt     time.Time `db:"applied_at"`
+	DownMigration string    `db:"down_migration"`
 }
 
 var MigrationDialects = map[string]gorp.Dialect{
@@ -401,8 +401,9 @@ func ExecMax(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirecti
 		switch dir {
 		case Up:
 			err = executor.Insert(&MigrationRecord{
-				Id:        migration.Id,
-				AppliedAt: time.Now(),
+				Id:            migration.Id,
+				AppliedAt:     time.Now(),
+				DownMigration: strings.Join(migration.Down, "\n"),
 			})
 			if err != nil {
 				if trans, ok := executor.(*gorp.Transaction); ok {
@@ -543,9 +544,11 @@ func SkipMax(db *sql.DB, dialect string, m MigrationSource, dir MigrationDirecti
 		}
 
 		err = executor.Insert(&MigrationRecord{
-			Id:        migration.Id,
-			AppliedAt: time.Now(),
+			Id:            migration.Id,
+			AppliedAt:     time.Now(),
+			DownMigration: strings.Join(migration.Down, "\n"),
 		})
+
 		if err != nil {
 			if trans, ok := executor.(*gorp.Transaction); ok {
 				trans.Rollback()

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -557,3 +557,22 @@ func (s *SqliteMigrateSuite) TestExecWithUnknownMigrationInDatabase(c *C) {
 	_, err = s.DbMap.Exec("SELECT age FROM people")
 	c.Assert(err, NotNil)
 }
+
+// TestSaveDownMigration makes sure that down migration saved in db
+func (s *SqliteMigrateSuite) TestSaveDownMigration(c *C) {
+	migrations := &MemoryMigrationSource{
+		Migrations: sqliteMigrations[:1],
+	}
+
+	SetTable(`migrations`)
+
+	n, err := Exec(s.Db, "sqlite3", migrations, Up)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 1)
+
+	// Can use table now
+	d, err := s.DbMap.SelectStr("SELECT down_migration FROM migrations WHERE down_migration IS NOT NULL")
+	c.Assert(err, IsNil)
+	c.Assert(d, Equals, sqliteMigrations[0].Down[0])
+
+}


### PR DESCRIPTION
Saves migrations down in the database.